### PR TITLE
Update CONTRIBUTING.md to clarify cloning instructions with a placeholder for username

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,8 +19,9 @@ If you have any questions, please check our [FAQs](Faqs.md) for answers.
 - Clone on your local machine
 
 ```terminal
-git clone https://github.com/lmpu/Halo-Semesta25.git
+git clone https://github.com/<username>/Halo-Semesta25.git
 ```
+Note: Use your git username, you can see that in the URL of your fork.
 - Navigate to project directory.
 ```terminal
 cd Halo-Semesta25


### PR DESCRIPTION
While cloning the fork, replaced lmpu with <username> for more clarity of new users. They will have their own git username in the URL here. 